### PR TITLE
De-duplicate C++ build file

### DIFF
--- a/C++/build.gradle
+++ b/C++/build.gradle
@@ -29,26 +29,3 @@ model {
     }
 
 }
-
-model {
-    components {
-        adis16448imu(NativeLibrarySpec) {
-            targetPlatform wpi.platforms.roborio
-
-            sources.cpp {
-                source {
-                    srcDir 'src/main/cpp'
-                }
-                exportedHeaders {
-                    srcDir 'src/main/include'
-                    if (includeSrcInIncludeRoot) {
-                        srcDir 'src/main/cpp'
-                    }
-                }
-            }
-
-            // Defining my dependencies. In this case, WPILib
-            useLibrary(it, "wpilib")
-        }
-    }
-}


### PR DESCRIPTION
C++ builds fail due to a duplicated section in build.gradle. This removes the duplicated section, fixing local builds. (Jitpack builds are still broken and will require additional build config changes.)