### PR TITLE
Use Arrays rather then ByteBuffers for JNI calls

### DIFF
--- a/java/src/main/java/com/analog/adis16448/frc/ADIS16448_IMU.java
+++ b/java/src/main/java/com/analog/adis16448/frc/ADIS16448_IMU.java
@@ -382,7 +382,7 @@ public class ADIS16448_IMU extends GyroBase implements Gyro, PIDSource, Sendable
     return buf[0] << 8 & buf[1];
   }
   static int ToUShort(int... data) {
-	  ByteBuffer buf = ByteBuffer.allocateDirect(data.length);
+	  ByteBuffer buf = ByteBuffer.allocate(data.length);
 	  for(int d : data) {
 		  buf.put((byte)d);
 	  }


### PR DESCRIPTION
ByteBuffers are very slow in Java. For the readRegister and writeRegister, the byte[] calls are faster then the ByteBuffer calls at length 2. In addition, allocating a byte[] is much faster then allocating a Direct Byte Buffer.

For the auto SPI call, at your length the int[] call is slower, but you are accessing lots of bytes in the Java side.
The Java side array read is exponentially faster, and is worth it over the bytebuffer call.

I don't have a device to test this, but I would be interested if this fixes some of the utilization issues. I have a theory it will.